### PR TITLE
fix: place mode attribute prevents stacking

### DIFF
--- a/DanaTweaks/src/BlockBehavior/BlockBehaviorSelectSlabToolMode.cs
+++ b/DanaTweaks/src/BlockBehavior/BlockBehaviorSelectSlabToolMode.cs
@@ -70,6 +70,10 @@ public class BlockBehaviorSelectSlabToolMode : BlockBehavior
 
     public override void SetToolMode(ItemSlot slot, IPlayer byPlayer, BlockSelection blockSelection, int toolMode)
     {
+        if (toolMode == 0)
+        {
+            slot.Itemstack.Attributes.RemoveAttribute("slabPlaceMode");
+        }
         slot.Itemstack.Attributes.SetInt("slabPlaceMode", toolMode);
     }
 


### PR DESCRIPTION
When setting the slab place mode to Auto slabs will not stack with other non modified ones.

Crafted "Auto Mode" slabs do not have the "slabPlaceMode" as such whenever you switch back to auto mod using dana tweaks slabs may not stack with non modified ones.

<img width="614" height="365" alt="image" src="https://github.com/user-attachments/assets/904bc86e-b638-4149-9f17-0c2af97fd81f" />

<img width="624" height="439" alt="image" src="https://github.com/user-attachments/assets/f0f45b03-bbd9-4011-b7bb-173793ec1a72" />
