### PR TITLE
feat: bump version to .net10 + fix recipe api names

### DIFF
--- a/CakeBuild/CakeBuild.csproj
+++ b/CakeBuild/CakeBuild.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
     <PackageReference Include="Cake.Json" Version="7.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.5-beta1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/DanaTweaks/DanaTweaks.csproj
+++ b/DanaTweaks/DanaTweaks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-	<TargetFramework>net8.0</TargetFramework>
+	<TargetFramework>net10.0</TargetFramework>
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	<OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
 	</PropertyGroup>

--- a/DanaTweaks/src/Systems/Recipes.cs
+++ b/DanaTweaks/src/Systems/Recipes.cs
@@ -1,14 +1,9 @@
-using System.Collections.Generic;
-using System.Linq;
 using Vintagestory.API.Common;
-using Vintagestory.ServerMods;
 
 namespace DanaTweaks;
 
 public class Recipes : ModSystem
 {
-    public GridRecipeLoader GridRecipeLoader { get; set; }
-
     public override double ExecuteOrder() => 1.1;
 
     public override void AssetsLoaded(ICoreAPI api)
@@ -18,15 +13,13 @@ public class Recipes : ModSystem
             return;
         }
 
-        GridRecipeLoader = api.ModLoader.GetModSystem<GridRecipeLoader>();
-
         foreach (GridRecipe recipe in api.World.GridRecipes)
         {
             if (Core.ConfigServer.FourPlanksFromLog)
             {
-                if (recipe.Output.ResolvedItemstack != null && recipe.HasLogAsIngredient() && recipe.Output.IsPlank())
+                if (recipe.Output.ResolvedItemStack != null && recipe.HasLogAsIngredient() && recipe.Output.IsPlank())
                 {
-                    recipe.Output.ResolvedItemstack.StackSize = 4;
+                    recipe.Output.ResolvedItemStack.StackSize = 4;
                 }
             }
         }


### PR DESCRIPTION
Mod was crashing in 1.22.

- Updates to net10
- Fixes recipe api new naming

Haven't done thorough testing tho. 

Tested and compiled against config lib 1.11.0